### PR TITLE
Linear Interpolator for `JointSpacePath` Execution

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,9 +1,12 @@
 [flake8]
 max-line-length = 88
 extend-ignore = E203
-exclude =
-    .env
-    env
-    .venv
-    venv
-    lisdf-models
+exclude = (?x)(
+    .env/
+    | env/
+    | .venv/
+    | venv/
+    | lisdf-models/
+    | pybullet-planning/
+    | kitchen-worlds/
+  )

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,3 +1,3 @@
 [settings]
 profile = black
-skip =.env,env,.venv,venv,lisdf-models
+skip =.env,env,.venv,venv,lisdf-models,pybullet-planning,kitchen-worlds

--- a/lisdf/plan_executor/interpolator.py
+++ b/lisdf/plan_executor/interpolator.py
@@ -1,0 +1,79 @@
+from abc import ABC, abstractmethod
+
+import numpy as np
+
+
+class PathInterpolator(ABC):
+    """Used so we can abstract simulator's interpolator out of the executor."""
+
+    def __init__(self, t_all: np.ndarray, confs: np.ndarray):
+        """
+        Let n be the number of configurations and q be the number of joints
+        in the configuration.
+
+        Parameters
+        ----------
+        t_all: 1-d array of shape (n, ) with the times for each configuration point.
+            This array must be sorted.
+        confs: 2-d array of shape (n, q) where each row represents a robot conf.
+            Subsequently, there is a conf for each time in t_all.
+        """
+        if t_all.shape[0] != confs.shape[0]:
+            raise ValueError("t_all and confs must be the same length.")
+        elif not np.allclose(np.sort(t_all), t_all):
+            raise ValueError("t_all must be sorted")
+
+        self.t_all = t_all
+        self.confs = confs
+
+    @abstractmethod
+    def value(self, t: float) -> np.ndarray:
+        """
+        Get the interpolated joint values for the given time t.
+        Returns a 1-d array shape (q, ) where q is the number of joints.
+        """
+        raise NotImplementedError
+
+
+class NearestTimeInterpolator(PathInterpolator):
+    def value(self, t: float) -> np.ndarray:
+        # Find the index of the value with closest time to t.
+        # Could improve to O(log n) but less readable.
+        shifted_t_all = np.abs(self.t_all - t)
+        closest_t_idx = np.argmin(shifted_t_all)
+        return self.confs[closest_t_idx]
+
+
+class LinearInterpolator(PathInterpolator):
+    """
+    Simple implementation of linear interpolation.
+    https://en.wikipedia.org/wiki/Linear_interpolation
+
+    If the time provided is:
+    - before the first time, we return the first configuration.
+    - after last time, we return the last configuration.
+    - otherwise, we use linear interpolation
+    """
+
+    def __init__(self, t_all: np.ndarray, confs: np.ndarray):
+        super().__init__(t_all, confs)
+        intervals = zip(t_all, t_all[1:], confs, confs[1:])
+        self.slopes = [(y2 - y1) / (x2 - x1) for x1, x2, y1, y2 in intervals]
+        assert len(self.slopes) == len(t_all) - 1
+
+    def value(self, t: float) -> np.ndarray:
+        if t < self.t_all[0]:
+            # Return first configuration if time earlier
+            return self.confs[0]
+        elif t >= self.t_all[-1]:
+            # Return last configuration if time later
+            return self.confs[-1]
+
+        # Find index of t_x, where t_x <= t < t_y
+        # i.e. the configuration and slope we should use for interpolating
+        # https://numpy.org/doc/stable/reference/generated/numpy.searchsorted.html
+        idx = np.searchsorted(self.t_all, t, side="right") - 1
+
+        # Use the standard linear interpolation formula
+        conf = self.confs[idx] + self.slopes[idx] * (t - self.t_all[idx])
+        return conf

--- a/lisdf/plan_executor/joint_space_path_executor.py
+++ b/lisdf/plan_executor/joint_space_path_executor.py
@@ -1,50 +1,12 @@
 import warnings
-from abc import ABC, abstractmethod
 from typing import ClassVar, Type
 
 import numpy as np
 
 from lisdf.plan_executor.executor import CommandExecutor
+from lisdf.plan_executor.interpolator import PathInterpolator
 from lisdf.plan_executor.robots.common import Robot
 from lisdf.planner_output.command import JointSpacePath
-
-
-class PathInterpolator(ABC):
-    """Used so we can abstract simulator's interpolator out of the executor."""
-
-    def __init__(self, t_all: np.ndarray, confs: np.ndarray):
-        """
-        Let n be the number of configurations and q be the number of joints
-        in the configuration.
-
-        Parameters
-        ----------
-        t_all: 1-d array of shape (n, ) with the times for each configuration point
-        confs: 2-d array of shape (n, q) where each row represents a robot conf.
-            Subsequently, there is a conf for each time in t_all.
-        """
-        if t_all.shape[0] != confs.shape[0]:
-            raise ValueError("t_all and confs must be the same length.")
-
-        self.t_all = t_all
-        self.confs = confs
-
-    @abstractmethod
-    def value(self, t: float) -> np.ndarray:
-        """
-        Get the interpolated joint values for the given time t.
-        Returns a 1-d array shape (q, ) where q is the number of joints.
-        """
-        raise NotImplementedError
-
-
-class NearestTimeInterpolator(PathInterpolator):
-    def value(self, t: float) -> np.ndarray:
-        # Find the index of the value with closest time to t.
-        # Could improve to O(log n) but less readable.
-        shifted_t_all = np.abs(self.t_all - t)
-        closest_t_idx = np.argmin(shifted_t_all)
-        return self.confs[closest_t_idx]
 
 
 class JointSpacePathExecutor(CommandExecutor):

--- a/lisdf/plan_executor/lisdf_executor.py
+++ b/lisdf/plan_executor/lisdf_executor.py
@@ -3,10 +3,8 @@ from typing import Dict, Type, cast
 
 from lisdf.plan_executor.executor import CommandExecutor
 from lisdf.plan_executor.gripper_executor import ActuateGripperExecutor
-from lisdf.plan_executor.joint_space_path_executor import (
-    JointSpacePathExecutor,
-    PathInterpolator,
-)
+from lisdf.plan_executor.interpolator import PathInterpolator
+from lisdf.plan_executor.joint_space_path_executor import JointSpacePathExecutor
 from lisdf.plan_executor.robots.common import Robot
 from lisdf.planner_output.command import ActuateGripper, Command, JointSpacePath
 from lisdf.planner_output.plan import LISDFPlan

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,12 +2,15 @@
 strict_equality = True
 disallow_untyped_calls = True
 warn_unreachable = True
-exclude =
-    .env
-    env
-    .venv
-    venv
-    lisdf-models
+exclude = (?x)(
+    .env/
+    | env/
+    | .venv/
+    | venv/
+    | lisdf-models/
+    | pybullet-planning/
+    | kitchen-worlds/
+  )
 
 # Allow untyped in the SDF parsing we modified from urdf_parser_py
 [mypy-lisdf.parsing.*]

--- a/tests/test_plan_executor/test_interpolator.py
+++ b/tests/test_plan_executor/test_interpolator.py
@@ -31,9 +31,15 @@ NEAREST_TIME_INTERPOLATOR_TEST_CASES = [
     "interpolator_cls", [LinearInterpolator, NearestTimeInterpolator]
 )
 def test_interpolator_raises_error(interpolator_cls):
+    # Number of timesteps does not equal number of configurations
     with pytest.raises(ValueError):
-        # Number of timesteps does not equal number of configurations
         interpolator_cls(t_all=np.array([0.0, 1.0]), confs=np.array([[0.0, 0.0, 0.1]]))
+
+    # Timesteps are not sorted
+    with pytest.raises(ValueError):
+        interpolator_cls(
+            t_all=np.array([0.2, 0.5, 0.3]), confs=np.array([[0.0], [0.1], [0.2]])
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_plan_executor/test_interpolator.py
+++ b/tests/test_plan_executor/test_interpolator.py
@@ -1,0 +1,98 @@
+import numpy as np
+import pytest
+
+from lisdf.plan_executor.interpolator import LinearInterpolator, NearestTimeInterpolator
+from lisdf.planner_output.command import JointSpacePath
+
+
+@pytest.fixture
+def joint_space_path(panda_waypoints) -> JointSpacePath:
+    return JointSpacePath(
+        waypoints=panda_waypoints,
+        duration=6.0,
+        label="complex_joint_space_path",
+    )
+
+
+NEAREST_TIME_INTERPOLATOR_TEST_CASES = [
+    # (time, expected configuration index)
+    pytest.param(-1.0, 0, id="time_before_start"),
+    pytest.param(0.4999, 0, id="initial_configuration"),
+    pytest.param(0.5, 0, id="tie_breaking"),
+    pytest.param(0.5001, 1, id="edge_case_second_configuration"),
+    pytest.param(0.999, 1, id="second_configuration"),
+    pytest.param(5.501, -1, id="edge_case_last_configuration"),
+    pytest.param(6.0, -1, id="last_configuration"),
+    pytest.param(999, -1, id="time_beyond_duration"),
+]
+
+
+def test_interpolator_raises_error():
+    with pytest.raises(ValueError):
+        # Number of timesteps does not equal number of configurations
+        NearestTimeInterpolator(
+            t_all=np.array([0.0, 1.0]), confs=np.array([[0.0, 0.0, 0.1]])
+        )
+
+
+@pytest.mark.parametrize(
+    "time, expected_configuration_idx",
+    NEAREST_TIME_INTERPOLATOR_TEST_CASES,
+)
+def test_nearest_time_interpolator(
+    time, expected_configuration_idx, panda, joint_space_path
+):
+    # NearestTimeInterpolator interpolates to the waypoint with the nearest time.
+    # Ties (i.e., at 0.5) are broken by choosing the waypoint that came first in time.
+    interpolator = NearestTimeInterpolator(
+        t_all=np.linspace(
+            0.0, joint_space_path.duration, joint_space_path.num_waypoints
+        ),
+        confs=joint_space_path.waypoints_as_np_array(panda.joint_ordering),
+    )
+    assert np.allclose(
+        interpolator.value(time),
+        joint_space_path.waypoint_as_np_array(
+            expected_configuration_idx, panda.joint_ordering
+        ),
+    )
+
+
+def test_linear_interpolator(joint_space_path, panda):
+    interpolator = LinearInterpolator(
+        t_all=np.linspace(
+            0.0, joint_space_path.duration, joint_space_path.num_waypoints
+        ),
+        confs=joint_space_path.waypoints_as_np_array(panda.joint_ordering),
+    )
+
+    def waypoint_at(idx_):
+        return joint_space_path.waypoint_as_np_array(idx_, panda.joint_ordering)
+
+    # At time 0.0, the configuration is the first waypoint.
+    assert np.allclose(interpolator.value(0.0), waypoint_at(0))
+
+    # In between first and second waypoint (i.e., idx = 0 and 1),
+    # check that it linearly interpolates
+    slope = (waypoint_at(1) - waypoint_at(0)) / (interpolator.t_all[1])
+    for time in np.linspace(0.0, interpolator.t_all[1], 50):
+        assert np.allclose(interpolator.value(time), waypoint_at(0) + slope * time)
+
+    # In between second and third waypoint (i.e., idx = 1 and 2),
+    # check that it linearly interpolates
+    slope = (waypoint_at(2) - waypoint_at(1)) / (
+        interpolator.t_all[2] - interpolator.t_all[1]
+    )
+    for time in np.linspace(interpolator.t_all[1], interpolator.t_all[2], 50):
+        assert np.allclose(
+            interpolator.value(time),
+            waypoint_at(1) + slope * (time - interpolator.t_all[1]),
+        )
+
+    # At end of command, the configuration is the last waypoint.
+    assert np.allclose(interpolator.value(joint_space_path.duration), waypoint_at(-1))
+
+    # Check that interpolator returns us the configuration at each given timestep
+    # i.e., we want the robot to be at the configuration within the split duration
+    for idx, time in enumerate(interpolator.t_all):
+        assert np.allclose(interpolator.value(time), interpolator.confs[idx])

--- a/tests/test_plan_executor/test_joint_space_path_executor.py
+++ b/tests/test_plan_executor/test_joint_space_path_executor.py
@@ -1,11 +1,12 @@
 import numpy as np
 import pytest
 
-from lisdf.plan_executor.joint_space_path_executor import (
-    JointSpacePathExecutor,
-    NearestTimeInterpolator,
-)
+from lisdf.plan_executor.interpolator import NearestTimeInterpolator
+from lisdf.plan_executor.joint_space_path_executor import JointSpacePathExecutor
 from lisdf.planner_output.command import JointSpacePath
+from tests.test_plan_executor.test_interpolator import (
+    NEAREST_TIME_INTERPOLATOR_TEST_CASES,
+)
 
 
 @pytest.fixture
@@ -17,54 +18,10 @@ def joint_space_path(panda_waypoints) -> JointSpacePath:
     )
 
 
-_TIME_AND_EXPECTED_CONFIGURATIONS = [
-    # (time, expected configuration index)
-    pytest.param(-1.0, 0, id="time_before_start"),
-    pytest.param(0.4999, 0, id="initial_configuration"),
-    pytest.param(0.5, 0, id="tie_breaking"),
-    pytest.param(0.5001, 1, id="edge_case_second_configuration"),
-    pytest.param(0.999, 1, id="second_configuration"),
-    pytest.param(5.501, -1, id="edge_case_last_configuration"),
-    pytest.param(6.0, -1, id="last_configuration"),
-    pytest.param(999, -1, id="time_beyond_duration"),
-]
-
-
 @pytest.fixture
 def executor(panda, joint_space_path) -> JointSpacePathExecutor:
     return JointSpacePathExecutor(
         panda, joint_space_path, 0.0, interpolator_cls=NearestTimeInterpolator
-    )
-
-
-def test_interpolator_raises_error():
-    with pytest.raises(ValueError):
-        # Number of timesteps does not equal number of configurations
-        NearestTimeInterpolator(
-            t_all=np.array([0.0, 1.0]), confs=np.array([[0.0, 0.0, 0.1]])
-        )
-
-
-@pytest.mark.parametrize(
-    "time, expected_configuration_idx",
-    _TIME_AND_EXPECTED_CONFIGURATIONS,
-)
-def test_nearest_time_interpolator(
-    time, expected_configuration_idx, panda, joint_space_path
-):
-    # NearestTimeInterpolator interpolates to the waypoint with the nearest time.
-    # Ties (i.e., at 0.5) are broken by choosing the waypoint that came first in time.
-    interpolator = NearestTimeInterpolator(
-        t_all=np.linspace(
-            0.0, joint_space_path.duration, joint_space_path.num_waypoints
-        ),
-        confs=joint_space_path.waypoints_as_np_array(panda.joint_ordering),
-    )
-    assert np.allclose(
-        interpolator.value(time),
-        joint_space_path.waypoint_as_np_array(
-            expected_configuration_idx, panda.joint_ordering
-        ),
     )
 
 
@@ -87,7 +44,7 @@ def test_joint_space_path_executor_creates_interpolator(
 @pytest.mark.parametrize(
     "time, expected_configuration_idx",
     # Since we use the NearestTimeInterpolator, we can reuse test cases here
-    _TIME_AND_EXPECTED_CONFIGURATIONS,
+    NEAREST_TIME_INTERPOLATOR_TEST_CASES,
 )
 def test_joint_space_path_executor_execute(
     time, expected_configuration_idx, executor, panda, joint_space_path

--- a/tests/test_plan_executor/test_lisdf_executor.py
+++ b/tests/test_plan_executor/test_lisdf_executor.py
@@ -2,10 +2,8 @@ import pytest
 from mock import Mock, call
 
 from lisdf.plan_executor.gripper_executor import ActuateGripperExecutor
-from lisdf.plan_executor.joint_space_path_executor import (
-    JointSpacePathExecutor,
-    NearestTimeInterpolator,
-)
+from lisdf.plan_executor.interpolator import NearestTimeInterpolator
+from lisdf.plan_executor.joint_space_path_executor import JointSpacePathExecutor
 from lisdf.plan_executor.lisdf_executor import LISDFPlanExecutor, NoExecutorFoundError
 from lisdf.planner_output.command import ActuateGripper, GripperPosition, JointSpacePath
 from lisdf.planner_output.plan import LISDFPlan


### PR DESCRIPTION
- Uses numpy so we don't have to rely on Drake
- Updated unit tests
- Update flake8/mypy/isort config so they actually work (ignores pybullet-planning and kitchen-world which some of us probably have in our workspaces)