### PR TITLE
add py.typed file so that mypy uses type annotations in other projects

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
         "lark",
     ],
     include_package_data=True,
+    package_data={"lisdf": ["py.typed"]},  # for mypy
     extras_require={
         "develop": [
             # Formatting


### PR DESCRIPTION
context:
* https://stackoverflow.com/questions/68639273/why-does-mypy-state-found-module-but-no-typehints-eventhough-there-are-actu/68671774#68671774
* https://blog.whtsky.me/tech/2021/dont-forget-py.typed-for-your-typed-python-package/