### PR TITLE
explicitly add py.typed to setup.py package data 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
         "numpy",
         "lark",
     ],
-    package_data={"lisdf": ["lisdf/**", "py.typed"]},  # mypy, pddl files
+    package_data={"lisdf": ["py.typed"]},  # mypy, pddl files
     extras_require={
         "develop": [
             # Formatting

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
         "numpy",
         "lark",
     ],
-    package_data={"lisdf": ["lisdf/**", "lisdf/py.typed"]},  # mypy, pddl files
+    package_data={"lisdf": ["lisdf/**", "py.typed"]},  # mypy, pddl files
     extras_require={
         "develop": [
             # Formatting

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
         "numpy",
         "lark",
     ],
-    package_data={"lisdf": ["lisdf/**"]},  # mypy and pddl files
+    package_data={"lisdf": ["lisdf/**", "lisdf/py.typed"]},  # mypy, pddl files
     extras_require={
         "develop": [
             # Formatting

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
         "numpy",
         "lark",
     ],
-    package_data={"lisdf": ["py.typed"]},  # mypy, pddl files
+    package_data={"lisdf": ["lisdf/**", "py.typed"]},  # mypy, pddl files
     extras_require={
         "develop": [
             # Formatting


### PR DESCRIPTION
this should fix the type checking issues we're having in repos that depend on this one.

e.g.: https://github.com/Learning-and-Intelligent-Systems/predicators/actions/runs/3128093055/jobs/5075497487